### PR TITLE
Phase 1: Fix Maven test setup, parsing, and test isolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,30 @@ Toy Robot Challenge
 
 ### Run the app
 
-1. Open up IntelliJ IDE -> right click java/com.andywong.cli/TextInputInferface ->Run TextInputfae
-2. Input the commands as this [link](https://github.com/ioof-holdings/recruitment/wiki/Robot-Challenge)
+From the project root:
+
+```bash
+mvn compile exec:java
+```
+
+Then enter commands (one per line) as described in the [Robot Challenge spec](https://github.com/luke-zhou/robot-challenge). End input with a blank line.
+
+Example:
+
+```
+PLACE 0,0,NORTH
+MOVE
+REPORT
+```
 
 ### Run tests
-* Open up IntelliJ IDE -> right click test/java folder -> Run Tests
 
+```bash
+mvn test
+```
 
 ## Environment
 
-- Java 20
+- Java 21
 - Maven
-- JUnit 4.13
+- JUnit 5

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ mvn test
 - Maven
 - JUnit 5
 
-## Historical notes
+## Documentation
 
-For context on why the app and test suite were unreliable before the Phase 1 refactor (broken `mvn test`, flaky tests, `PLACE` parsing, IntelliJ-only run instructions), see [docs/HISTORICAL_NOTES.md](docs/HISTORICAL_NOTES.md).
+- [Refactor roadmap](docs/REFACTOR_ROADMAP.md) — phased plan (Phase 1 done; Phases 2–4 pending)
+- [Historical notes](docs/HISTORICAL_NOTES.md) — why the app and test suite were unreliable before Phase 1

--- a/README.md
+++ b/README.md
@@ -32,3 +32,7 @@ mvn test
 - Java 21
 - Maven
 - JUnit 5
+
+## Historical notes
+
+For context on why the app and test suite were unreliable before the Phase 1 refactor (broken `mvn test`, flaky tests, `PLACE` parsing, IntelliJ-only run instructions), see [docs/HISTORICAL_NOTES.md](docs/HISTORICAL_NOTES.md).

--- a/docs/HISTORICAL_NOTES.md
+++ b/docs/HISTORICAL_NOTES.md
@@ -151,5 +151,6 @@ The project also listed `junit:junit:4.13.2` alongside `junit-jupiter:RELEASE`, 
 
 ## References
 
+- [Refactor roadmap](REFACTOR_ROADMAP.md) — phased plan including Phase 1 (done) and Phases 2–4 (pending)
 - [Robot Challenge spec (community mirror)](https://github.com/luke-zhou/robot-challenge)
 - Phase 1 PR: https://github.com/awongCM/java-toy-robot/pull/2

--- a/docs/HISTORICAL_NOTES.md
+++ b/docs/HISTORICAL_NOTES.md
@@ -1,0 +1,155 @@
+# Historical Notes — Pre-Refactor Issues
+
+This document records why the Toy Robot app was difficult to run, test, and maintain **before** the Phase 1 refactor (see PR #2). It is kept as context for future work (Phase 2 and beyond).
+
+---
+
+## Summary
+
+The core domain logic (`Direction`, `Grid`, `Robot`) was largely correct, but **build tooling**, **CLI parsing**, and **test isolation** problems made the project appear broken when run outside IntelliJ.
+
+| Symptom | Root cause |
+|---------|------------|
+| `mvn test` reported success but ran **0 tests** | JUnit 5 tests with no Surefire JUnit 5 configuration |
+| Tests passed individually, failed as a suite | Shared singleton state (`Grid`, `Robot`) leaked between tests |
+| `PLACE 0,0,NORTH` failed at runtime | CLI split parameters on `", "` (comma + space) instead of `","` |
+| No clear way to run from the terminal | README only documented IntelliJ steps (with typos) |
+| Java version confusion | `pom.xml` declared Java 20 in properties but compiled with Java 11 |
+
+---
+
+## 1. Tests did not run under Maven
+
+### What we saw
+
+```text
+Tests run: 0, Failures: 0, Errors: 0, Skipped: 0
+BUILD SUCCESS
+```
+
+Maven reported success, but **no tests executed**.
+
+### Why
+
+- Test classes used **JUnit Jupiter** (`org.junit.jupiter.api.Test`).
+- `pom.xml` depended on both JUnit 4 and JUnit 5, with `junit-jupiter` pinned to `RELEASE`.
+- **maven-surefire-plugin** was not configured for JUnit 5, so Surefire defaulted to the JUnit 4 provider and silently skipped Jupiter tests.
+
+### Why it seemed to work in IntelliJ
+
+IntelliJ runs JUnit 5 tests directly via its own test runner, bypassing Maven Surefire. That hid the fact that `mvn test` was a no-op.
+
+---
+
+## 2. Tests were order-dependent (flaky suite)
+
+### What we saw
+
+Developers noted in `GridTest` and `TextInputInterfaceTest`:
+
+> need to investigate why running tests individually passes but failed when running together
+
+### Why
+
+`Robot` and `Grid` were implemented as **singletons**:
+
+```java
+// Robot.java — single shared instance for the entire JVM
+private static Robot _instance;
+public static Robot getInstance() { ... }
+
+// Grid.java — same pattern
+private static Grid _instance;
+public static Grid getInstance() { ... }
+
+// TextInputInterface.java — static reference held for the life of the process
+public static final Grid grid = Grid.getInstance();
+```
+
+Each test that placed or moved the robot left state behind for the next test. `TextInputInterfaceTest` also captured `System.out` in a static buffer that was never cleared between tests.
+
+`GridTest` used `new Grid()` per test, but every `Grid` still shared the **same** `Robot` singleton, so isolation was illusory.
+
+---
+
+## 3. PLACE command parsing failed on real input
+
+### What we saw
+
+Valid challenge input such as `PLACE 0,0,NORTH` could throw:
+
+```text
+The PLACE command must have three parameters: X,Y,DIRECTION
+```
+
+### Why
+
+`TextInputInterface.placePosition()` split the parameter string on `", "` (comma **and** space):
+
+```java
+String[] locationParams = paramsAsString.split(", ");
+```
+
+The Robot Challenge format uses commas **without** spaces (`0,0,NORTH`). That split produced a single token, failed the length check, and rejected the command.
+
+Some test paths happened to work because `getCommandWithOrWithoutParams()` round-tripped parameters through `Arrays.toString()`, which injects spaces (`"0, 0, NORTH"`). That masked the bug for tests that used the same workaround, but not for real stdin input.
+
+---
+
+## 4. App was not runnable from the command line
+
+### What we saw
+
+The README instructed:
+
+1. Open IntelliJ
+2. Right-click `java/com.andywong.cli/TextInputInferface` *(typo)*
+3. Run `TextInputfae` *(typo)*
+
+There was no documented Maven or `java` command. `pom.xml` had no `exec-maven-plugin` or `mainClass` configuration.
+
+### Other CLI rough edges
+
+- `getLineFeedFromInput()` printed the raw command list to stdout (`System.out.println(commands)`), polluting output during interactive use.
+- A broad `catch (Exception e)` swallowed errors with a typo: `"something when wrong"`.
+
+---
+
+## 5. Build configuration inconsistencies
+
+### `pom.xml` problems (pre-refactor)
+
+| Setting | Value A | Value B |
+|---------|---------|---------|
+| `maven.compiler.source` / `target` in `<properties>` | `1.20` | — |
+| `maven-compiler-plugin` `<source>` / `<target>` | — | `11` |
+
+The project also listed `junit:junit:4.13.2` alongside `junit-jupiter:RELEASE`, which is non-reproducible and unnecessary when all tests use Jupiter.
+
+---
+
+## 6. What Phase 1 fixed (and what it did not)
+
+### Fixed in Phase 1
+
+- Maven Surefire + JUnit 5 → all **39 tests** run via `mvn test`
+- Java 21 alignment and pinned JUnit version
+- `mvn compile exec:java` to run the CLI
+- `PLACE` parsing accepts `0,0,NORTH` (comma-separated, trimmed)
+- `resetForTesting()` helpers and per-test stdout reset
+- README updated with correct Maven instructions
+
+### Intentionally deferred (Phase 2+)
+
+- Removing singletons in favour of dependency injection
+- Spec-aligned behaviour (ignore invalid moves and pre-`PLACE` commands instead of throwing)
+- File-based input (`commands.txt`)
+- Canonical integration tests from the official challenge examples
+- Domain cleanup (`Location` `hashCode`, `Integer` vs `int`, injectable table size)
+
+---
+
+## References
+
+- [Robot Challenge spec (community mirror)](https://github.com/luke-zhou/robot-challenge)
+- Phase 1 PR: https://github.com/awongCM/java-toy-robot/pull/2

--- a/docs/REFACTOR_ROADMAP.md
+++ b/docs/REFACTOR_ROADMAP.md
@@ -1,0 +1,259 @@
+# Refactor Roadmap
+
+This document tracks the planned refactor phases for the Toy Robot challenge. It covers what has been completed and what remains, so work can proceed incrementally without losing context.
+
+For background on **why** Phase 1 was needed, see [HISTORICAL_NOTES.md](HISTORICAL_NOTES.md).
+
+---
+
+## Overview
+
+| Phase | Focus | Status |
+|-------|-------|--------|
+| [Phase 1](#phase-1--quick-wins) | Build tooling, parsing, test isolation | **Done** |
+| [Phase 2](#phase-2--spec-aligned-behavior) | Challenge spec compliance, integration tests, file input | Pending |
+| [Phase 3](#phase-3--clean-architecture) | Remove singletons, separate concerns, domain cleanup | Pending |
+| [Phase 4](#phase-4--polish) | Optional hardening, CI, edge-case coverage | Pending |
+
+**Recommended order:** Phase 1 → Phase 2 → Phase 3 → Phase 4 (optional).
+
+Phase 2 can ship independently of Phase 3. Phase 3 is the larger structural refactor and should follow once behavior is spec-correct and well tested.
+
+---
+
+## Phase 1 — Quick wins
+
+**Status:** Done (PR [#2](https://github.com/awongCM/java-toy-robot/pull/2))
+
+**Goal:** Make the project runnable, testable, and trustworthy from the command line without changing core domain behavior.
+
+### Completed items
+
+- [x] Fix `pom.xml` for **Java 21** with consistent compiler source/target
+- [x] Remove duplicate JUnit 4 dependency; use **JUnit 5** with a pinned version
+- [x] Configure **maven-surefire-plugin** so `mvn test` runs all tests (was 0 tests)
+- [x] Add **exec-maven-plugin** for `mvn compile exec:java`
+- [x] Fix `PLACE` parsing to accept comma-separated values (`0,0,NORTH`) with trim
+- [x] Remove debug `System.out.println(commands)` from stdin loop
+- [x] Fix CLI error message typo (`"something when wrong"`)
+- [x] Add `resetForTesting()` helpers on `Grid`, `Robot`, and `TextInputInterface`
+- [x] Reset captured stdout buffer in `TextInputInterfaceTest` between tests
+- [x] Update `README.md` with Maven run/test instructions
+- [x] Add [HISTORICAL_NOTES.md](HISTORICAL_NOTES.md) documenting pre-refactor failures
+
+### Verification
+
+```bash
+mvn test
+# Tests run: 39, Failures: 0, Errors: 0, Skipped: 0
+```
+
+### Explicitly deferred
+
+Phase 1 intentionally did **not** change:
+
+- Singleton architecture (`Grid.getInstance()`, `Robot.getInstance()`)
+- Exception-throwing behavior for invalid moves or pre-`PLACE` commands
+- File-based input
+- Domain model cleanup (`Location`, `hashCode`, injectable table size)
+
+---
+
+## Phase 2 — Spec-aligned behavior
+
+**Status:** Pending
+
+**Goal:** Align runtime behavior with the [Robot Challenge spec](https://github.com/luke-zhou/robot-challenge) and add confidence through integration tests and file input.
+
+### Planned items
+
+- [ ] **Ignore commands before first valid `PLACE`**
+  - `MOVE`, `LEFT`, `RIGHT`, and `REPORT` should be no-ops until the robot is placed
+  - Currently throws `IllegalStateException("The robot hasn't been placed")`
+
+- [ ] **Ignore moves that would fall off the table**
+  - Invalid moves should be silently ignored; robot position unchanged
+  - Currently throws `IllegalStateException("The robot will fall")`
+
+- [ ] **Ignore invalid `PLACE` commands**
+  - Out-of-bounds or malformed placement should be ignored (not throw)
+  - Valid `PLACE` after an invalid one should still work
+
+- [ ] **Update existing tests** to reflect spec-aligned behavior
+  - Replace exception assertions with state assertions (position/direction unchanged)
+  - Keep tests for truly invalid input parsing (malformed CLI strings)
+
+- [ ] **Add canonical integration tests** for the three official examples:
+
+  | Input | Expected output |
+  |-------|-----------------|
+  | `PLACE 0,0,NORTH` → `MOVE` → `REPORT` | `0,1,NORTH` |
+  | `PLACE 0,0,NORTH` → `LEFT` → `REPORT` | `0,0,WEST` |
+  | `PLACE 1,2,EAST` → `MOVE` → `MOVE` → `LEFT` → `MOVE` → `REPORT` | `3,3,NORTH` |
+
+- [ ] **Support file-based input**
+  - Read commands from a file path argument (e.g. `commands.txt`)
+  - Fall back to stdin when no file is provided
+  - Example: `mvn compile exec:java -Dexec.args="commands.txt"`
+
+- [ ] **Clarify `REPORT` when robot is not placed**
+  - Spec allows ignoring `REPORT` before placement
+  - Decide: silent no-op vs. empty output (document the choice)
+
+### Suggested approach
+
+Introduce a thin **simulator/orchestrator** layer that interprets commands according to the spec, even if the underlying `Grid` methods still throw internally at first. This keeps Phase 2 changes localized before the Phase 3 structural refactor.
+
+### Acceptance criteria
+
+- All canonical examples pass
+- `mvn test` green with updated behavior tests
+- App runs against `commands.txt` and produces expected output
+- No regressions in Phase 1 tooling (`mvn test`, `mvn compile exec:java`)
+
+---
+
+## Phase 3 — Clean architecture
+
+**Status:** Pending
+
+**Goal:** Restructure the codebase for maintainability, testability, and interview/portfolio quality — without singletons or mixed responsibilities.
+
+### Planned items
+
+#### Remove singletons
+
+- [ ] Remove `Robot.getInstance()` and `Grid.getInstance()`
+- [ ] Use constructor injection: `new Table(width, height, new Robot())`
+- [ ] Remove `resetForTesting()` workarounds (no longer needed)
+- [ ] Each test creates a fresh simulator/table instance
+
+#### Separate concerns
+
+- [ ] **Domain layer** — pure logic, no I/O
+  - `Direction` (enum)
+  - `Position` (rename from `Location`)
+  - `Robot` (state holder)
+  - `Table` (rename from `Grid`; bounds + place/move/rotate)
+
+- [ ] **Application layer** — command orchestration
+  - `RobotSimulator` applies parsed commands and returns optional report output
+
+- [ ] **CLI layer** — parsing and printing only
+  - `Command` (enum)
+  - `CommandParser` (string → typed command)
+  - `App` / `TextInputInterface` (stdin or file input)
+
+#### Domain cleanup
+
+- [ ] Rename `Location` → `Position`
+- [ ] Use `int` for x/y instead of `Integer` (eliminate null-coordinate guards)
+- [ ] Fix `Location.hashCode()` to match `equals()` (currently uses `super.hashCode()`)
+- [ ] Make table size injectable/configurable (default 5×5)
+- [ ] Remove awkward `Arrays.toString()` round-trip in command parameter handling
+
+#### Target package layout
+
+```
+com.andywong
+├── domain/
+│   ├── Direction.java
+│   ├── Position.java
+│   ├── Robot.java
+│   └── Table.java
+├── application/
+│   └── RobotSimulator.java
+├── cli/
+│   ├── Command.java
+│   ├── CommandParser.java
+│   └── App.java
+└── (tests mirror the above)
+```
+
+#### Test reorganization
+
+- [ ] Mirror package structure in test directory
+- [ ] Unit tests for domain (no CLI dependencies)
+- [ ] Integration tests for simulator + canonical examples
+- [ ] Thin CLI smoke tests only
+
+### Acceptance criteria
+
+- No static mutable singleton state
+- Domain classes have zero imports from CLI or `System.out`
+- All Phase 2 integration tests still pass
+- `mvn test` green with improved test isolation (no `@BeforeEach` reset hacks)
+
+---
+
+## Phase 4 — Polish
+
+**Status:** Pending (optional)
+
+**Goal:** Harden the project for long-term maintenance and demonstration.
+
+### Planned items
+
+- [ ] **Custom exceptions** (only where fail-fast is genuinely desired)
+  - Separate parsing errors from domain no-ops
+  - Document which layer throws vs. ignores
+
+- [ ] **Parameterized tests** for edge cases
+  - All four table edges (north, south, east, west)
+  - Corner positions
+  - Multiple consecutive invalid moves
+  - Re-`PLACE` mid-session
+
+- [ ] **CI pipeline**
+  - GitHub Actions (or similar) running `mvn test` on push/PR
+  - Optionally: Java version matrix (21)
+
+- [ ] **README polish**
+  - Architecture diagram
+  - Example file-input usage
+  - Link to roadmap and historical notes
+
+- [ ] **Code quality**
+  - Remove dead code and commented-out blocks
+  - Consistent naming (`Grid` → `Table` references in docs)
+  - Consider records for `Position` (Java 21)
+
+### Acceptance criteria
+
+- CI badge or documented CI workflow
+- Edge-case coverage beyond the three canonical examples
+- README sufficient for a new developer to run, test, and understand the design
+
+---
+
+## Architecture target (end state)
+
+After Phase 3 and 4, the flow should look like this:
+
+```mermaid
+flowchart LR
+    Input[stdin or file] --> Parser[CommandParser]
+    Parser --> Simulator[RobotSimulator]
+    Simulator --> Table[Table 5x5]
+    Table --> Robot[Robot state]
+    Simulator --> Output[REPORT output]
+```
+
+---
+
+## Related documents
+
+| Document | Purpose |
+|----------|---------|
+| [HISTORICAL_NOTES.md](HISTORICAL_NOTES.md) | Why the app failed before Phase 1 |
+| [../README.md](../README.md) | How to run the app and tests today |
+| [Robot Challenge spec](https://github.com/luke-zhou/robot-challenge) | Official challenge requirements |
+
+---
+
+## Notes for contributors
+
+- **Prefer incremental PRs** — one phase (or a logical slice of a phase) per PR
+- **Keep tests green** — update assertions when behavior intentionally changes (especially Phase 2)
+- **Do not skip Phase 2** before Phase 3 unless you accept rework — spec behavior should be locked in before restructuring packages
+- Phase 1's `resetForTesting()` helpers are a bridge; remove them in Phase 3 when singletons are gone

--- a/pom.xml
+++ b/pom.xml
@@ -1,42 +1,53 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLOCATION="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
+    <groupId>com.andywong</groupId>
+    <artifactId>java-toy-robot</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
     <properties>
-        <maven.compiler.source>1.20</maven.compiler.source>
-        <maven.compiler.target>1.20</maven.compiler.target>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <junit.version>5.10.2</junit.version>
     </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>21</source>
+                    <target>21</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.2.5</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.3.0</version>
+                <configuration>
+                    <mainClass>com.andywong.cli.TextInputInterface</mainClass>
                 </configuration>
             </plugin>
         </plugins>
     </build>
-
-    <groupId>groupId</groupId>
-    <artifactId>java-toy-robot</artifactId>
-    <version>1.0-SNAPSHOT</version>
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.13.2</version>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-            <version>RELEASE</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
-
-
 </project>

--- a/src/main/java/com/andywong/cli/TextInputInterface.java
+++ b/src/main/java/com/andywong/cli/TextInputInterface.java
@@ -17,7 +17,12 @@ public class TextInputInterface {
     private static final int X_POSITION = 0;
     private static final int Y_POSITION = 1;
 
-    public static final Grid grid = Grid.getInstance();
+    private static Grid grid = Grid.getInstance();
+
+    static void resetForTesting() {
+        Grid.resetForTesting();
+        grid = Grid.getInstance();
+    }
 
     public TextInputInterface(){}
 
@@ -31,8 +36,8 @@ public class TextInputInterface {
 
             try{
                 runCommand(commandInput);
-            }catch (Exception e) {
-                System.out.println("something when wrong: " + e.toString());
+            } catch (Exception e) {
+                System.out.println("Something went wrong: " + e.getMessage());
             }
         }
     }
@@ -43,10 +48,14 @@ public class TextInputInterface {
             throw new IllegalArgumentException(INVALID_PLACE_PARAMETERS);
         }
 
-        String [] locationParams = paramsAsString.split(", ");
+        String[] locationParams = paramsAsString.split(",");
 
         if (locationParams.length != 3) {
             throw new IllegalArgumentException(INVALID_PLACE_PARAMETERS);
+        }
+
+        for (int i = 0; i < locationParams.length; i++) {
+            locationParams[i] = locationParams[i].trim();
         }
 
         Location location = getLocationFromParams(locationParams);
@@ -122,12 +131,10 @@ public class TextInputInterface {
 
         List<String> commands = new ArrayList<String>();
 
-        while ( !(line = scanner.nextLine()).isEmpty()) {
-
+        while (!(line = scanner.nextLine()).isEmpty()) {
             commands.add(line);
         }
 
-        System.out.println(commands);
         scanner.close();
 
         return  commands;

--- a/src/main/java/com/andywong/components/Grid.java
+++ b/src/main/java/com/andywong/components/Grid.java
@@ -26,6 +26,15 @@ public class Grid {
         return _instance;
     }
 
+    public static void resetForTesting() {
+        _instance = null;
+        Robot.resetForTesting();
+    }
+
+    void clearState() {
+        robot.clearState();
+    }
+
     public void place(Location location, Direction direction) {
         if (location == null) {
             throw new IllegalArgumentException(NO_LOCATION_ERROR_MESSAGE);

--- a/src/main/java/com/andywong/components/Robot.java
+++ b/src/main/java/com/andywong/components/Robot.java
@@ -14,6 +14,15 @@ public class Robot {
         return _instance;
     }
 
+    static void resetForTesting() {
+        _instance = null;
+    }
+
+    void clearState() {
+        location = null;
+        direction = null;
+    }
+
     public void setLocation(Location location) {
         this.location = location;
     }

--- a/src/test/java/com/andywong/cli/TextInputInterfaceTest.java
+++ b/src/test/java/com/andywong/cli/TextInputInterfaceTest.java
@@ -1,7 +1,5 @@
 package com.andywong.cli;
 
-import com.andywong.components.Grid;
-import com.andywong.components.Robot;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -23,11 +21,12 @@ public class TextInputInterfaceTest {
 
     private TextInputInterface textInputInterface;
 
-    // TODO - need to investigate why running tests individually passes but failed when running
-    // together
+    // Tests reset shared singleton state before each run so the suite is order-independent.
 
     @BeforeEach
     public void beforeEach() {
+        TextInputInterface.resetForTesting();
+        outContent.reset();
         textInputInterface = new TextInputInterface();
     }
 

--- a/src/test/java/com/andywong/components/GridTest.java
+++ b/src/test/java/com/andywong/components/GridTest.java
@@ -1,5 +1,7 @@
 package com.andywong.components;
 
+import com.andywong.components.Grid;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -7,8 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class GridTest {
 
-    // TODO - need to investigate why running tests individually passes but failed when running
-    // together
+    @BeforeEach
+    void setUp() {
+        Grid.resetForTesting();
+    }
+
+    // Shared singleton state is reset before each test so the suite is order-independent.
     @Test
     void place_should_throw_IllegalArgumentException_when_no_coordinate_are_set() {
         // Arrange


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 1 quick wins for the Toy Robot challenge — fixes build tooling, CLI parsing, and flaky test isolation without changing core domain behavior.

Also adds documentation for pre-refactor context and the full refactor plan.

## Changes

### Build & tooling (`pom.xml`)
- Align on **Java 21** (consistent compiler source/target)
- Remove duplicate JUnit 4 dependency; use **JUnit 5** only with a pinned version
- Configure **maven-surefire-plugin** so `mvn test` actually runs all tests (was previously 0 tests)
- Add **exec-maven-plugin** so the app can be run with `mvn compile exec:java`

### CLI fixes (`TextInputInterface`)
- Fix `PLACE` parsing to split on `,` and trim whitespace (handles `0,0,NORTH` without requiring spaces)
- Remove debug `System.out.println(commands)` from the stdin loop
- Fix error message typo (`"something when wrong"` → `"Something went wrong"`)

### Test isolation
- Add `resetForTesting()` helpers on `Grid`, `Robot`, and `TextInputInterface` to clear singleton state between tests
- Reset captured stdout buffer in `TextInputInterfaceTest` `@BeforeEach`
- Resolves the long-standing issue where tests passed individually but failed when run together

### Documentation
- Fix README typos and replace IntelliJ-only instructions with Maven commands
- Add **`docs/HISTORICAL_NOTES.md`** — pre-refactor failure analysis
- Add **`docs/REFACTOR_ROADMAP.md`** — phased plan (Phase 1 done; Phases 2–4 pending with checklists)

## Test plan

- [x] `mvn test` — **39 tests, 0 failures**
- [x] Verified Surefire runs JUnit 5 tests across all four test classes

## Next up (Phase 2)

See [docs/REFACTOR_ROADMAP.md](docs/REFACTOR_ROADMAP.md) for full details.

- Align behavior with the Robot Challenge spec (ignore invalid moves and pre-PLACE commands)
- Add canonical example integration tests
- Support file-based input (`commands.txt`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3914fe8c-6acb-4ff1-a6cc-33f918439b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3914fe8c-6acb-4ff1-a6cc-33f918439b0d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

