### PR TITLE
Set up Cursor Cloud development environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a single-module Java 21 / Maven CLI app (the "Toy Robot" challenge). There is only one service: the command-line program.
+
+- Build/test/run commands are documented in `README.md` (`mvn test`, `mvn compile exec:java`). The app's main class is `com.andywong.cli.TextInputInterface`.
+- There is no separate lint step; correctness is enforced by the JUnit 5 test suite (`mvn test`).
+- The CLI reads commands from stdin, one per line, and **stops at the first blank line**. When running non-interactively, pipe input that ends with a blank line, e.g. `printf 'PLACE 0,0,NORTH\nMOVE\nREPORT\n\n' | mvn -q compile exec:java`. `REPORT` is what prints output; without it the program produces nothing.
+- Maven (3.8.x) is a system dependency provided by the VM image, not by the repo. Java 21 is the required JDK.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for this Java 21 / Maven "Toy Robot" CLI app and documents non-obvious run caveats for future cloud agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the single CLI service, build/test/run commands, and the key gotcha that the CLI reads stdin until the first blank line (so piped input must end with a blank line and include `REPORT` to produce output).

## Environment
- **JDK:** Java 21 (already present on the image)
- **Maven:** 3.8.7 (installed as a system dependency)
- **Update script:** `mvn -q -B dependency:go-offline` (warms the dependency/plugin cache; idempotent)

## Verification
- `mvn test` → 39 tests pass, BUILD SUCCESS
- `printf 'PLACE 0,0,NORTH\nMOVE\nREPORT\n\n' | mvn -q compile exec:java` → `0,1,NORTH`
- `printf 'PLACE 1,2,EAST\nMOVE\nMOVE\nLEFT\nMOVE\nREPORT\n\n' | mvn -q compile exec:java` → `3,3,NORTH` (matches canonical spec example)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4c572961-421a-4f69-851f-0e7da59f0f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c572961-421a-4f69-851f-0e7da59f0f81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

