### PR TITLE
Phase 2 (3a): Spec-aligned behavior via RobotSimulator

### DIFF
--- a/docs/REFACTOR_ROADMAP.md
+++ b/docs/REFACTOR_ROADMAP.md
@@ -61,29 +61,30 @@ Phase 1 intentionally did **not** change:
 
 ## Phase 2 — Spec-aligned behavior
 
-**Status:** Pending
+**Status:** In progress (slice 3a: behavior — PR pending)
 
 **Goal:** Align runtime behavior with the [Robot Challenge spec](https://github.com/luke-zhou/robot-challenge) and add confidence through integration tests and file input.
 
 ### Planned items
 
-- [ ] **Ignore commands before first valid `PLACE`**
+- [x] **Ignore commands before first valid `PLACE`** (slice 3a)
   - `MOVE`, `LEFT`, `RIGHT`, and `REPORT` should be no-ops until the robot is placed
-  - Currently throws `IllegalStateException("The robot hasn't been placed")`
+  - Implemented via `RobotSimulator` — catches `IllegalStateException` from `Grid`
 
-- [ ] **Ignore moves that would fall off the table**
+- [x] **Ignore moves that would fall off the table** (slice 3a)
   - Invalid moves should be silently ignored; robot position unchanged
-  - Currently throws `IllegalStateException("The robot will fall")`
+  - Implemented via `RobotSimulator`
 
-- [ ] **Ignore invalid `PLACE` commands**
+- [x] **Ignore invalid `PLACE` commands** (slice 3a)
   - Out-of-bounds or malformed placement should be ignored (not throw)
   - Valid `PLACE` after an invalid one should still work
+  - Parser-level malformed input still throws; out-of-bounds ignored by simulator
 
-- [ ] **Update existing tests** to reflect spec-aligned behavior
-  - Replace exception assertions with state assertions (position/direction unchanged)
-  - Keep tests for truly invalid input parsing (malformed CLI strings)
+- [x] **Update existing tests** to reflect spec-aligned behavior (slice 3a)
+  - `RobotSimulatorTest` and updated `TextInputInterfaceTest`
+  - `GridTest` unchanged — domain layer still throws internally
 
-- [ ] **Add canonical integration tests** for the three official examples:
+- [ ] **Add canonical integration tests** for the three official examples (slice 3b):
 
   | Input | Expected output |
   |-------|-----------------|
@@ -91,14 +92,13 @@ Phase 1 intentionally did **not** change:
   | `PLACE 0,0,NORTH` → `LEFT` → `REPORT` | `0,0,WEST` |
   | `PLACE 1,2,EAST` → `MOVE` → `MOVE` → `LEFT` → `MOVE` → `REPORT` | `3,3,NORTH` |
 
-- [ ] **Support file-based input**
+- [ ] **Support file-based input** (slice 3c)
   - Read commands from a file path argument (e.g. `commands.txt`)
   - Fall back to stdin when no file is provided
   - Example: `mvn compile exec:java -Dexec.args="commands.txt"`
 
-- [ ] **Clarify `REPORT` when robot is not placed**
-  - Spec allows ignoring `REPORT` before placement
-  - Decide: silent no-op vs. empty output (document the choice)
+- [x] **Clarify `REPORT` when robot is not placed** (slice 3a)
+  - Silent no-op: `RobotSimulator.report()` returns empty; CLI prints nothing
 
 ### Suggested approach
 

--- a/src/main/java/com/andywong/application/RobotSimulator.java
+++ b/src/main/java/com/andywong/application/RobotSimulator.java
@@ -1,0 +1,63 @@
+package com.andywong.application;
+
+import com.andywong.components.Direction;
+import com.andywong.components.Grid;
+import com.andywong.components.Location;
+
+import java.util.Optional;
+
+/**
+ * Applies robot commands according to the challenge spec: invalid placements,
+ * pre-PLACE commands, and moves that would fall off the table are silently ignored.
+ */
+public class RobotSimulator {
+
+    private final Grid grid;
+
+    public RobotSimulator(Grid grid) {
+        this.grid = grid;
+    }
+
+    public void place(Location location, Direction direction) {
+        try {
+            grid.place(location, direction);
+        } catch (IllegalArgumentException e) {
+            // Out-of-bounds or otherwise invalid placement — ignore per spec
+        }
+    }
+
+    public void move() {
+        try {
+            grid.move();
+        } catch (IllegalStateException e) {
+            // Not placed or would fall off the table — ignore per spec
+        }
+    }
+
+    public void left() {
+        try {
+            grid.left();
+        } catch (IllegalStateException e) {
+            // Not placed — ignore per spec
+        }
+    }
+
+    public void right() {
+        try {
+            grid.right();
+        } catch (IllegalStateException e) {
+            // Not placed — ignore per spec
+        }
+    }
+
+    /**
+     * Returns report output when the robot is placed; empty when not placed (silent no-op).
+     */
+    public Optional<String> report() {
+        String result = grid.report();
+        if ("The robot hasn't been placed".equals(result)) {
+            return Optional.empty();
+        }
+        return Optional.of(result);
+    }
+}

--- a/src/main/java/com/andywong/cli/TextInputInterface.java
+++ b/src/main/java/com/andywong/cli/TextInputInterface.java
@@ -1,5 +1,6 @@
 package com.andywong.cli;
 
+import com.andywong.application.RobotSimulator;
 import com.andywong.components.Direction;
 import com.andywong.components.Grid;
 import com.andywong.components.Location;
@@ -18,10 +19,12 @@ public class TextInputInterface {
     private static final int Y_POSITION = 1;
 
     private static Grid grid = Grid.getInstance();
+    private static RobotSimulator simulator = new RobotSimulator(grid);
 
     static void resetForTesting() {
         Grid.resetForTesting();
         grid = Grid.getInstance();
+        simulator = new RobotSimulator(grid);
     }
 
     public TextInputInterface(){}
@@ -60,13 +63,11 @@ public class TextInputInterface {
 
         Location location = getLocationFromParams(locationParams);
         Direction direction = Direction.find(locationParams[DIRECTION_POSITION]);
-        grid.place(location, direction);
+        simulator.place(location, direction);
     }
 
     private static void reportRobotPosition() {
-        String robotPosition = grid.report();
-
-        System.out.println(robotPosition);
+        simulator.report().ifPresent(System.out::println);
     }
 
     public static void runCommand(String [] commandInput) {
@@ -79,13 +80,13 @@ public class TextInputInterface {
                 placePosition(commandInput[1]);
                 break;
             case MOVE:
-                grid.move();
+                simulator.move();
                 break;
             case LEFT:
-                grid.left();
+                simulator.left();
                 break;
             case RIGHT:
-                grid.right();
+                simulator.right();
                 break;
             case REPORT:
                 reportRobotPosition();

--- a/src/test/java/com/andywong/application/RobotSimulatorTest.java
+++ b/src/test/java/com/andywong/application/RobotSimulatorTest.java
@@ -1,0 +1,75 @@
+package com.andywong.application;
+
+import com.andywong.components.Direction;
+import com.andywong.components.Grid;
+import com.andywong.components.Location;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RobotSimulatorTest {
+
+    private Grid grid;
+    private RobotSimulator simulator;
+
+    @BeforeEach
+    void setUp() {
+        Grid.resetForTesting();
+        grid = new Grid();
+        simulator = new RobotSimulator(grid);
+    }
+
+    @Test
+    void move_beforePlace_isIgnored() {
+        simulator.move();
+        assertEquals(Optional.empty(), simulator.report());
+    }
+
+    @Test
+    void left_beforePlace_isIgnored() {
+        simulator.left();
+        assertEquals(Optional.empty(), simulator.report());
+    }
+
+    @Test
+    void right_beforePlace_isIgnored() {
+        simulator.right();
+        assertEquals(Optional.empty(), simulator.report());
+    }
+
+    @Test
+    void report_beforePlace_returnsEmpty() {
+        assertTrue(simulator.report().isEmpty());
+    }
+
+    @Test
+    void move_offTable_isIgnored() {
+        simulator.place(new Location(0, 0), Direction.WEST);
+        simulator.move();
+        assertEquals(Optional.of("0,0,WEST"), simulator.report());
+    }
+
+    @Test
+    void invalidPlace_isIgnored() {
+        simulator.place(new Location(5, 5), Direction.NORTH);
+        assertEquals(Optional.empty(), simulator.report());
+    }
+
+    @Test
+    void validPlace_afterInvalidPlace_succeeds() {
+        simulator.place(new Location(5, 5), Direction.NORTH);
+        simulator.place(new Location(0, 0), Direction.NORTH);
+        assertEquals(Optional.of("0,0,NORTH"), simulator.report());
+    }
+
+    @Test
+    void move_afterValidPlace_updatesPosition() {
+        simulator.place(new Location(0, 0), Direction.NORTH);
+        simulator.move();
+        assertEquals(Optional.of("0,1,NORTH"), simulator.report());
+    }
+}

--- a/src/test/java/com/andywong/cli/TextInputInterfaceTest.java
+++ b/src/test/java/com/andywong/cli/TextInputInterfaceTest.java
@@ -48,18 +48,16 @@ public class TextInputInterfaceTest {
     }
 
     @Test
-    void runCommand_throw_exception_when_robot_have_not_been_placed() {
+    void runCommand_MOVE_beforePlace_isIgnored() {
         // Arrange
         String command = "move";
-        String [] commandInput = {command, null};
-        String expected = "The robot hasn't been placed";
+        String[] commandInput = {command, null};
 
         // Act
-        Throwable exception = assertThrows(IllegalStateException.class, () -> textInputInterface.runCommand(commandInput));
-
+        textInputInterface.runCommand(commandInput);
 
         // Assert
-        assertEquals(expected, exception.getMessage());
+        assertEquals("", outContent.toString());
     }
 
     @Test
@@ -161,6 +159,53 @@ public class TextInputInterfaceTest {
 
         // Assert
         assertEquals(expected, outContent.toString());
+    }
+
+    @Test
+    void runCommand_REPORT_beforePlace_printsNothing() {
+        // Arrange
+        String[] commandInput = {Command.REPORT.name(), null};
+
+        // Act
+        textInputInterface.runCommand(commandInput);
+
+        // Assert
+        assertEquals("", outContent.toString());
+    }
+
+    @Test
+    void runCommand_MOVE_offTable_isIgnored() {
+        // Arrange
+        String[] params = new String[]{"0", "0", "WEST"};
+        String[] placeInput = {Command.PLACE.name(), Arrays.toString(params).replace("[", "").replace("]", "")};
+        String[] moveInput = {Command.MOVE.name(), null};
+        String[] reportInput = {Command.REPORT.name(), null};
+
+        // Act
+        textInputInterface.runCommand(placeInput);
+        textInputInterface.runCommand(moveInput);
+        textInputInterface.runCommand(reportInput);
+
+        // Assert
+        assertEquals("0,0,WEST", outContent.toString().trim());
+    }
+
+    @Test
+    void runCommand_invalidPlace_isIgnored_thenValidPlaceWorks() {
+        // Arrange
+        String[] invalidParams = new String[]{"5", "5", "NORTH"};
+        String[] validParams = new String[]{"0", "0", "NORTH"};
+        String[] invalidPlace = {Command.PLACE.name(), Arrays.toString(invalidParams).replace("[", "").replace("]", "")};
+        String[] validPlace = {Command.PLACE.name(), Arrays.toString(validParams).replace("[", "").replace("]", "")};
+        String[] reportInput = {Command.REPORT.name(), null};
+
+        // Act
+        textInputInterface.runCommand(invalidPlace);
+        textInputInterface.runCommand(validPlace);
+        textInputInterface.runCommand(reportInput);
+
+        // Assert
+        assertEquals("0,0,NORTH", outContent.toString().trim());
     }
 
     @Test


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 slice **3a** — introduces `RobotSimulator` to align runtime behavior with the [Robot Challenge spec](https://github.com/luke-zhou/robot-challenge).

- Silently ignores `MOVE` / `LEFT` / `RIGHT` / `REPORT` before the first valid `PLACE`
- Silently ignores moves that would fall off the table
- Silently ignores out-of-bounds `PLACE` commands (valid `PLACE` after invalid still works)
- `REPORT` before placement is a **silent no-op** (no output)
- Parser-level malformed `PLACE` input still throws (per roadmap)

`Grid` domain layer is unchanged and still throws internally; the simulator catches and ignores per spec.

## Changes

- New `com.andywong.application.RobotSimulator`
- `TextInputInterface` wired through the simulator
- `RobotSimulatorTest` + updated `TextInputInterfaceTest`
- Roadmap updated for completed 3a items

## Verification

```bash
mvn test
# Tests run: 50, Failures: 0, Errors: 0
```

## Merge order

**Merge this PR first.** Slices 3b and 3c depend on or conflict with this branch.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dbde0fd-e16b-44cb-b79e-96455c11fac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dbde0fd-e16b-44cb-b79e-96455c11fac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

