### PR TITLE
Phase 2 (3c): File-based command input

### DIFF
--- a/docs/REFACTOR_ROADMAP.md
+++ b/docs/REFACTOR_ROADMAP.md
@@ -61,7 +61,7 @@ Phase 1 intentionally did **not** change:
 
 ## Phase 2 — Spec-aligned behavior
 
-**Status:** In progress (slice 3a: behavior — PR pending)
+**Status:** In progress (slice 3c: file input — PR pending)
 
 **Goal:** Align runtime behavior with the [Robot Challenge spec](https://github.com/luke-zhou/robot-challenge) and add confidence through integration tests and file input.
 
@@ -92,7 +92,11 @@ Phase 1 intentionally did **not** change:
   | `PLACE 0,0,NORTH` → `LEFT` → `REPORT` | `0,0,WEST` |
   | `PLACE 1,2,EAST` → `MOVE` → `MOVE` → `LEFT` → `MOVE` → `REPORT` | `3,3,NORTH` |
 
+<<<<<<< HEAD
 - [ ] **Support file-based input** (slice 3c)
+=======
+- [x] **Support file-based input** (slice 3c)
+>>>>>>> ae06955 (Phase 2 slice 3c: file-based command input)
   - Read commands from a file path argument (e.g. `commands.txt`)
   - Fall back to stdin when no file is provided
   - Example: `mvn compile exec:java -Dexec.args="commands.txt"`

--- a/docs/REFACTOR_ROADMAP.md
+++ b/docs/REFACTOR_ROADMAP.md
@@ -92,11 +92,7 @@ Phase 1 intentionally did **not** change:
   | `PLACE 0,0,NORTH` → `LEFT` → `REPORT` | `0,0,WEST` |
   | `PLACE 1,2,EAST` → `MOVE` → `MOVE` → `LEFT` → `MOVE` → `REPORT` | `3,3,NORTH` |
 
-<<<<<<< HEAD
-- [ ] **Support file-based input** (slice 3c)
-=======
 - [x] **Support file-based input** (slice 3c)
->>>>>>> ae06955 (Phase 2 slice 3c: file-based command input)
   - Read commands from a file path argument (e.g. `commands.txt`)
   - Fall back to stdin when no file is provided
   - Example: `mvn compile exec:java -Dexec.args="commands.txt"`

--- a/src/main/java/com/andywong/cli/TextInputInterface.java
+++ b/src/main/java/com/andywong/cli/TextInputInterface.java
@@ -5,6 +5,9 @@ import com.andywong.components.Direction;
 import com.andywong.components.Grid;
 import com.andywong.components.Location;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -31,7 +34,7 @@ public class TextInputInterface {
 
     public static void main(String[] args) {
 
-        List<String> commands = getLineFeedFromInput();
+        List<String> commands = getCommands(args);
 
         for (String command: commands) {
             String [] commandlineAsArray = command.trim().split(" ");
@@ -124,6 +127,23 @@ public class TextInputInterface {
 
     }
 
+
+    private static List<String> getCommands(String[] args) {
+        if (args != null && args.length > 0 && args[0] != null && !args[0].isBlank()) {
+            return readCommandsFromFile(args[0].trim());
+        }
+        return getLineFeedFromInput();
+    }
+
+    private static List<String> readCommandsFromFile(String filePath) {
+        try {
+            return Files.readAllLines(Path.of(filePath)).stream()
+                    .takeWhile(line -> !line.isEmpty())
+                    .toList();
+        } catch (IOException e) {
+            throw new IllegalArgumentException("Could not read commands from file: " + filePath, e);
+        }
+    }
 
     private static List<String> getLineFeedFromInput() {
 

--- a/src/test/java/com/andywong/cli/TextInputInterfaceFileInputTest.java
+++ b/src/test/java/com/andywong/cli/TextInputInterfaceFileInputTest.java
@@ -1,0 +1,81 @@
+package com.andywong.cli;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class TextInputInterfaceFileInputTest {
+
+    private static final ByteArrayOutputStream outContent = new ByteArrayOutputStream();
+    private static final PrintStream originalOut = System.out;
+
+    @TempDir
+    Path tempDir;
+
+    @BeforeEach
+    void setUp() {
+        TextInputInterface.resetForTesting();
+        outContent.reset();
+    }
+
+    @BeforeAll
+    static void captureStdout() {
+        System.setOut(new PrintStream(outContent));
+    }
+
+    @AfterAll
+    static void restoreStdout() {
+        System.setOut(originalOut);
+    }
+
+    @Test
+    void main_readsCommandsFromFile() throws IOException {
+        Path commandsFile = tempDir.resolve("commands.txt");
+        Files.writeString(commandsFile, """
+                PLACE 0,0,NORTH
+                MOVE
+                REPORT
+                """);
+
+        TextInputInterface.main(new String[]{commandsFile.toString()});
+
+        assertEquals("0,1,NORTH", outContent.toString().trim());
+    }
+
+    @Test
+    void main_stopsAtBlankLineInFile() throws IOException {
+        Path commandsFile = tempDir.resolve("commands.txt");
+        Files.writeString(commandsFile, """
+                PLACE 0,0,NORTH
+                MOVE
+                REPORT
+
+                PLACE 1,1,EAST
+                REPORT
+                """);
+
+        TextInputInterface.main(new String[]{commandsFile.toString()});
+
+        assertEquals("0,1,NORTH", outContent.toString().trim());
+    }
+
+    @Test
+    void main_throwsWhenFileDoesNotExist() {
+        IllegalArgumentException ex = assertThrows(
+                IllegalArgumentException.class,
+                () -> TextInputInterface.main(new String[]{"nonexistent-commands.txt"})
+        );
+        assertEquals("Could not read commands from file: nonexistent-commands.txt", ex.getMessage());
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 2 slice **3c** — read commands from a file path argument; fall back to stdin when no file is provided.

```bash
mvn compile exec:java -Dexec.args="commands.txt"
```

- Reads lines from the file until the first blank line (same semantics as stdin)
- Throws `IllegalArgumentException` if the file cannot be read

## Merge order

**Merge after PR #3a** to avoid `TextInputInterface` merge conflicts with the `RobotSimulator` wiring. Rebase onto `main` after 3a lands if needed.

## Verification

```bash
mvn test
# Tests run: 42, Failures: 0, Errors: 0
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dbde0fd-e16b-44cb-b79e-96455c11fac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dbde0fd-e16b-44cb-b79e-96455c11fac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

