### PR TITLE
Phase 4 slice 4c: CLI parse exceptions and error docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,3 +37,4 @@ mvn test
 
 - [Refactor roadmap](docs/REFACTOR_ROADMAP.md) — phased plan (Phase 1 done; Phases 2–4 pending)
 - [Historical notes](docs/HISTORICAL_NOTES.md) — why the app and test suite were unreliable before Phase 1
+- [Error handling](docs/ERROR_HANDLING.md) — which layers throw vs. ignore

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -1,0 +1,37 @@
+# Error handling
+
+This project separates **parsing errors** (fail fast) from **domain no-ops** (silently ignored per the challenge spec).
+
+## Layer summary
+
+| Layer | Package | Invalid input | Mechanism |
+|-------|---------|---------------|-----------|
+| CLI / parsing | `com.andywong.cli` | Malformed `PLACE`, unknown command, unreadable file | `CommandParseException` |
+| Application | `com.andywong.application` | Off-table move, invalid placement, pre-`PLACE` command | Swallows domain exceptions; no-op |
+| Domain | `com.andywong.domain` | Out-of-bounds placement, fall-off move, unplaced robot | `IllegalArgumentException` / `IllegalStateException` (internal) |
+
+## CLI — fail fast
+
+`CommandParser` and `TextInputInterface` throw `CommandParseException` when:
+
+- The command token is not one of `PLACE`, `MOVE`, `LEFT`, `RIGHT`, `REPORT`
+- `PLACE` is missing parameters or has the wrong shape
+- Coordinates are not integers
+- A command file cannot be read
+
+`TextInputInterface.main` catches these and prints `Something went wrong: …` so a bad line does not crash the whole session.
+
+## Application — spec silent ignore
+
+`RobotSimulator` wraps `Table` and catches:
+
+- `IllegalArgumentException` from invalid `place` (out of bounds)
+- `IllegalStateException` from `move` / `left` / `right` when unplaced or would fall
+
+`report()` returns `Optional.empty()` when the robot is not placed.
+
+## Domain — throws internally
+
+`Table` validates placement and movement with standard Java exceptions. Callers outside tests should go through `RobotSimulator`, which translates throws into spec-compliant ignores.
+
+Direct use of `Table` in unit tests is intentional: tests assert the internal contract before the simulator layer applies spec semantics.

--- a/docs/REFACTOR_ROADMAP.md
+++ b/docs/REFACTOR_ROADMAP.md
@@ -211,9 +211,9 @@ mvn test
 
 ### Planned items
 
-- [ ] **Custom exceptions** (only where fail-fast is genuinely desired)
-  - Separate parsing errors from domain no-ops
-  - Document which layer throws vs. ignores
+- [x] **Custom exceptions** (slice 4c)
+  - `CommandParseException` for CLI/parsing errors
+  - Document which layer throws vs. ignores — [ERROR_HANDLING.md](ERROR_HANDLING.md)
 
 - [ ] **Parameterized tests** for edge cases
   - All four table edges (north, south, east, west)
@@ -231,9 +231,9 @@ mvn test
   - Link to roadmap and historical notes
 
 - [ ] **Code quality**
-  - Remove dead code and commented-out blocks
+  - [x] Remove dead code in `Command.matchAndReturnValidCommand`
   - Consistent naming (`Grid` → `Table` references in docs)
-  - Consider records for `Position` (Java 21)
+  - ~~Consider records for `Position` (Java 21)~~ — done in Phase 3
 
 ### Acceptance criteria
 
@@ -264,6 +264,7 @@ flowchart LR
 |----------|---------|
 | [HISTORICAL_NOTES.md](HISTORICAL_NOTES.md) | Why the app failed before Phase 1 |
 | [../README.md](../README.md) | How to run the app and tests today |
+| [ERROR_HANDLING.md](ERROR_HANDLING.md) | CLI vs application vs domain error contract |
 | [Robot Challenge spec](https://github.com/luke-zhou/robot-challenge) | Official challenge requirements |
 
 ---

--- a/src/main/java/com/andywong/cli/Command.java
+++ b/src/main/java/com/andywong/cli/Command.java
@@ -8,24 +8,15 @@ public enum Command {
     REPORT;
 
     public static Command matchAndReturnValidCommand(String command) {
-        try {
+        String sanitisedCommand = command.trim().toUpperCase();
 
-            String sanitisedCommand = command.trim().toUpperCase();
-
-            for (Command c: Command.values()) {
-                if (c.name().equals(sanitisedCommand)) {
-                    return c;
-                }
+        for (Command c : Command.values()) {
+            if (c.name().equals(sanitisedCommand)) {
+                return c;
             }
-
-            return null;
-
-        } catch(Exception e) {
-
-            System.out.println("Unknown command detected");
-            return null;
         }
 
+        return null;
     }
 }
 

--- a/src/main/java/com/andywong/cli/CommandParseException.java
+++ b/src/main/java/com/andywong/cli/CommandParseException.java
@@ -1,0 +1,16 @@
+package com.andywong.cli;
+
+/**
+ * Thrown when a command line cannot be parsed (malformed PLACE, unknown command, unreadable input file).
+ * Parsing errors fail fast; they are not silently ignored like invalid domain operations.
+ */
+public class CommandParseException extends RuntimeException {
+
+    public CommandParseException(String message) {
+        super(message);
+    }
+
+    public CommandParseException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/src/main/java/com/andywong/cli/CommandParser.java
+++ b/src/main/java/com/andywong/cli/CommandParser.java
@@ -23,6 +23,9 @@ public final class CommandParser {
         }
 
         Command command = Command.matchAndReturnValidCommand(commandToken);
+        if (command == null) {
+            throw new CommandParseException("Unknown command: " + commandToken);
+        }
         return new ParsedCommand(command, placeParameters);
     }
 }

--- a/src/main/java/com/andywong/cli/TextInputInterface.java
+++ b/src/main/java/com/andywong/cli/TextInputInterface.java
@@ -68,20 +68,20 @@ public class TextInputInterface {
                 reportRobotPosition();
                 break;
             default:
-                throw new RuntimeException("unknown command detected");
+                throw new CommandParseException("Unknown command detected");
         }
     }
 
     private void placePosition(String paramsAsString) {
 
         if (paramsAsString == null || paramsAsString.isBlank()) {
-            throw new IllegalArgumentException(INVALID_PLACE_PARAMETERS);
+            throw new CommandParseException(INVALID_PLACE_PARAMETERS);
         }
 
         String[] locationParams = paramsAsString.split(",");
 
         if (locationParams.length != 3) {
-            throw new IllegalArgumentException(INVALID_PLACE_PARAMETERS);
+            throw new CommandParseException(INVALID_PLACE_PARAMETERS);
         }
 
         for (int i = 0; i < locationParams.length; i++) {
@@ -104,8 +104,8 @@ public class TextInputInterface {
         try{
             x = Integer.parseInt(params[X_POSITION]);
             y = Integer.parseInt(params[Y_POSITION]);
-        }catch(NumberFormatException e) {
-            throw new IllegalArgumentException(INVALID_LOCATION_PARAMETERS);
+        } catch (NumberFormatException e) {
+            throw new CommandParseException(INVALID_LOCATION_PARAMETERS);
         }
 
         return new Position(x, y);
@@ -125,7 +125,7 @@ public class TextInputInterface {
                     .takeWhile(line -> !line.isEmpty())
                     .toList();
         } catch (IOException e) {
-            throw new IllegalArgumentException("Could not read commands from file: " + filePath, e);
+            throw new CommandParseException("Could not read commands from file: " + filePath, e);
         }
     }
 

--- a/src/test/java/com/andywong/cli/CommandParserTest.java
+++ b/src/test/java/com/andywong/cli/CommandParserTest.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 class CommandParserTest {
 
@@ -29,5 +30,14 @@ class CommandParserTest {
 
         assertEquals(Command.REPORT, parsed.command());
         assertNull(parsed.placeParameters());
+    }
+
+    @Test
+    void parse_unknownCommand_throws() {
+        CommandParseException ex = assertThrows(
+                CommandParseException.class,
+                () -> CommandParser.parse("JUMP")
+        );
+        assertEquals("Unknown command: JUMP", ex.getMessage());
     }
 }

--- a/src/test/java/com/andywong/cli/TextInputInterfaceFileInputTest.java
+++ b/src/test/java/com/andywong/cli/TextInputInterfaceFileInputTest.java
@@ -71,8 +71,8 @@ class TextInputInterfaceFileInputTest {
 
     @Test
     void main_throwsWhenFileDoesNotExist() {
-        IllegalArgumentException ex = assertThrows(
-                IllegalArgumentException.class,
+        CommandParseException ex = assertThrows(
+                CommandParseException.class,
                 () -> TextInputInterface.main(new String[]{"nonexistent-commands.txt"})
         );
         assertEquals("Could not read commands from file: nonexistent-commands.txt", ex.getMessage());

--- a/src/test/java/com/andywong/cli/TextInputInterfaceTest.java
+++ b/src/test/java/com/andywong/cli/TextInputInterfaceTest.java
@@ -50,7 +50,7 @@ public class TextInputInterfaceTest {
     void runCommand_throw_exception_when_PLACE_has_no_parameters() {
         String expected = "The PLACE command must have three parameters: X,Y,DIRECTION";
 
-        Throwable exception = assertThrows(IllegalArgumentException.class, () -> textInputInterface.runCommand("PLACE"));
+        Throwable exception = assertThrows(CommandParseException.class, () -> textInputInterface.runCommand("PLACE"));
 
         assertEquals(expected, exception.getMessage());
     }
@@ -59,7 +59,7 @@ public class TextInputInterfaceTest {
     void runCommand_throw_exception_when_PLACE_has_invalid_number_of_arguments() {
         String expected = "The PLACE command must have three parameters: X,Y,DIRECTION";
 
-        Throwable exception = assertThrows(IllegalArgumentException.class, () -> textInputInterface.runCommand("PLACE a,b"));
+        Throwable exception = assertThrows(CommandParseException.class, () -> textInputInterface.runCommand("PLACE a,b"));
 
         assertEquals(expected, exception.getMessage());
     }
@@ -68,7 +68,7 @@ public class TextInputInterfaceTest {
     void runCommand_throw_exception_when_PLACE_has_invalid_coordinate_params() {
         String expected = "Location must be integers";
 
-        Throwable exception = assertThrows(IllegalArgumentException.class, () -> textInputInterface.runCommand("PLACE a,b,c"));
+        Throwable exception = assertThrows(CommandParseException.class, () -> textInputInterface.runCommand("PLACE a,b,c"));
 
         assertEquals(expected, exception.getMessage());
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Phase 4 slice **4c**: typed CLI parse exceptions and layer documentation.

## Changes

- `CommandParseException` — malformed `PLACE`, unknown commands, unreadable files
- `CommandParser` throws on unknown command tokens
- `TextInputInterface` uses `CommandParseException` instead of generic `IllegalArgumentException` / `RuntimeException`
- Removed dead `try/catch` in `Command.matchAndReturnValidCommand`
- `docs/ERROR_HANDLING.md` — documents throw vs. ignore per layer
- Tests updated for new exception type; added unknown-command parser test

## Merge order

Merge **last** among Phase 4 slices (after 4a, 4b, 4d) to minimize README/roadmap conflicts.

## Verification

```bash
mvn test
# Tests run: 60, Failures: 0, Errors: 0, Skipped: 0
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2dbde0fd-e16b-44cb-b79e-96455c11fac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2dbde0fd-e16b-44cb-b79e-96455c11fac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

